### PR TITLE
Fix keyBackground attribute

### DIFF
--- a/app/src/main/res/drawable/keyboard_key_background.xml
+++ b/app/src/main/res/drawable/keyboard_key_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#EEE"/>
+</shape>

--- a/app/src/main/res/layout/keyboard_layout.xml
+++ b/app/src/main/res/layout/keyboard_layout.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_alignParentBottom="true"
-    android:keyBackground="#EEE"
+    android:keyBackground="@drawable/keyboard_key_background"
     android:keyTextColor="#000"
     android:keyTextSize="22sp"
     android:background="#DDD"/>


### PR DESCRIPTION
## Summary
- create `keyboard_key_background` drawable
- use drawable for `keyBackground`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d98dc708832aa762ca09b0d7e389