### PR TITLE
Fix Java 8 regex split

### DIFF
--- a/app/src/main/java/com/memekeyboard/AddMemeActivity.java
+++ b/app/src/main/java/com/memekeyboard/AddMemeActivity.java
@@ -70,7 +70,11 @@ public class AddMemeActivity extends Activity {
         }
 
         String keywordsString = keywordsEditText.getText().toString().trim();
-        Set<String> keywords = new HashSet<>(Arrays.asList(keywordsString.split(",\s*")));
+        // Java 8 does not support the "\s" escape sequence. Use a double
+        // backslash so the regular expression receives "\s*" instead of the
+        // unsupported string escape.
+        Set<String> keywords = new HashSet<>(Arrays.asList(
+                keywordsString.split(",\\s*")));
 
         try {
             memeManager.addMeme(selectedMemeUri, keywords);


### PR DESCRIPTION
## Summary
- escape regex `\s` so compilation works with Java 8

## Testing
- `javac --release 8 app/src/main/java/com/memekeyboard/AddMemeActivity.java`
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6877dc16f838832aa223b164b0c78276