### PR TITLE
Fix launcher activity missing

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -14,6 +14,16 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.MemeKeyboard">
 
+        <!-- Activity shown in the app drawer so users can manage their memes -->
+        <activity
+            android:name=".AddMemeActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
         <service
             android:name=".MemeKeyboardService"
             android:permission="android.permission.BIND_INPUT_METHOD"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,16 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.MemeKeyboard">
 
+        <!-- Activity shown in the app drawer so users can manage their memes -->
+        <activity
+            android:name=".AddMemeActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
         <service
             android:name=".MemeKeyboardService"
             android:permission="android.permission.BIND_INPUT_METHOD"


### PR DESCRIPTION
## Summary
- register `AddMemeActivity` in both manifests so the keyboard app appears in the launcher

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877dea650d0832aacc04d913e8a5a16