### PR TITLE
Fix keyboard visibility in settings

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -26,6 +26,7 @@
 
         <service
             android:name=".MemeKeyboardService"
+            android:label="@string/ime_name"
             android:permission="android.permission.BIND_INPUT_METHOD"
             android:exported="true">
             <intent-filter>

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Para compilar e instalar este teclado Android, siga os passos abaixo:
     b.  Procure por `Idioma e entrada` (Language & input) ou `Sistema > Idiomas e entrada`.
     c.  Em `Teclados`, selecione `Teclado virtual` (Virtual keyboard) ou `Gerenciar teclados` (Manage keyboards).
     d.  Ative o `Meme Keyboard`.
+        Se ele não aparecer imediatamente na lista, abra o aplicativo `Meme Keyboard` uma vez e volte para `Gerenciar teclados`.
     e.  Você pode ser avisado sobre os riscos de segurança de teclados de terceiros. Confirme para ativar.
 
 4.  **Alternar para o Teclado de Memes**: Ao usar qualquer aplicativo que exija entrada de texto (como um aplicativo de mensagens):

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
 
         <service
             android:name=".MemeKeyboardService"
+            android:label="@string/ime_name"
             android:permission="android.permission.BIND_INPUT_METHOD"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">Meme Keyboard</string>
+    <string name="ime_name">Meme Keyboard</string>
     <string name="subtype_generic">Meme Keyboard</string>
 </resources>
 


### PR DESCRIPTION
## Summary
- add explicit label for `MemeKeyboardService`
- mention opening the app if the keyboard doesn't appear

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e34b8868832aa0c7212c05fa3dee