### PR TITLE
Fix manifest meta-data for input method service

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -33,7 +33,7 @@
                 <action android:name="android.view.InputMethod" />
             </intent-filter>
             <meta-data
-                android:name="android.view.inputmethod"
+                android:name="android.view.im"
                 android:resource="@xml/method" />
         </service>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
                 <action android:name="android.view.InputMethod" />
             </intent-filter>
             <meta-data
-                android:name="android.view.inputmethod"
+                android:name="android.view.im"
                 android:resource="@xml/method" />
         </service>
 


### PR DESCRIPTION
## Summary
- correct the service meta-data tag name so Android can load the keyboard

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e6ccf3e0832a8bce70d689492e29