### PR TITLE
Enhance meme keyboard with typing support

### DIFF
--- a/app/src/main/java/com/memekeyboard/AddMemeActivity.java
+++ b/app/src/main/java/com/memekeyboard/AddMemeActivity.java
@@ -8,6 +8,8 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -21,6 +23,7 @@ public class AddMemeActivity extends Activity {
     private MemeManager memeManager;
 
     private EditText keywordsEditText;
+    private RadioGroup typeRadioGroup;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -30,6 +33,7 @@ public class AddMemeActivity extends Activity {
         memeManager = new MemeManager(this);
 
         keywordsEditText = findViewById(R.id.keywords_edit_text);
+        typeRadioGroup = findViewById(R.id.type_radio_group);
         Button selectMemeButton = findViewById(R.id.select_meme_button);
         Button saveMemeButton = findViewById(R.id.save_meme_button);
 
@@ -76,8 +80,10 @@ public class AddMemeActivity extends Activity {
         Set<String> keywords = new HashSet<>(Arrays.asList(
                 keywordsString.split(",\\s*")));
 
+        boolean asSticker = typeRadioGroup.getCheckedRadioButtonId() == R.id.sticker_radio;
+
         try {
-            memeManager.addMeme(selectedMemeUri, keywords);
+            memeManager.addMeme(selectedMemeUri, keywords, asSticker);
             Toast.makeText(this, "Meme salvo com sucesso!", Toast.LENGTH_SHORT).show();
             finish(); // Close activity after saving
         } catch (IOException e) {

--- a/app/src/main/java/com/memekeyboard/MemeKeyboardService.java
+++ b/app/src/main/java/com/memekeyboard/MemeKeyboardService.java
@@ -29,6 +29,7 @@ public class MemeKeyboardService extends InputMethodService implements KeyboardV
     private MemeManager memeManager;
     private GridView memeGridView;
     private MemeAdapter memeAdapter;
+    private EditText searchEditText;
 
     @Override
     public void onCreate() {
@@ -41,8 +42,13 @@ public class MemeKeyboardService extends InputMethodService implements KeyboardV
         View keyboardLayout = getLayoutInflater().inflate(R.layout.meme_gallery_layout, null);
 
         memeGridView = keyboardLayout.findViewById(R.id.meme_grid_view);
-        EditText searchEditText = keyboardLayout.findViewById(R.id.meme_search_edit_text);
+        searchEditText = keyboardLayout.findViewById(R.id.meme_search_edit_text);
+        keyboardView = keyboardLayout.findViewById(R.id.keyboard_view);
         Button addMemeButton = keyboardLayout.findViewById(R.id.add_meme_button);
+
+        keyboard = new Keyboard(this, R.xml.qwerty);
+        keyboardView.setKeyboard(keyboard);
+        keyboardView.setOnKeyboardActionListener(this);
 
         List<String> allMemePaths = new ArrayList<>(memeManager.getAllMemesWithKeywords().keySet());
         memeAdapter = new MemeAdapter(this, allMemePaths);
@@ -94,6 +100,38 @@ public class MemeKeyboardService extends InputMethodService implements KeyboardV
 
     @Override
     public void onKey(int primaryCode, int[] keyCodes) {
+        if (searchEditText == null) {
+            return;
+        }
+        switch (primaryCode) {
+            case Keyboard.KEYCODE_DELETE:
+                int length = searchEditText.getText().length();
+                if (length > 0) {
+                    searchEditText.getText().delete(length - 1, length);
+                }
+                break;
+            case Keyboard.KEYCODE_DONE:
+                InputConnection ic = getCurrentInputConnection();
+                if (ic != null) {
+                    ic.commitText("\n", 1);
+                }
+                break;
+            case Keyboard.KEYCODE_MODE_CHANGE:
+                // switch to next keyboard
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
+                    switchToNextInputMethod(false);
+                } else {
+                    requestShowSelf(0);
+                }
+                break;
+            case ' ':
+                searchEditText.append(" ");
+                break;
+            default:
+                char code = (char) primaryCode;
+                searchEditText.append(String.valueOf(code));
+                break;
+        }
     }
 
     @Override

--- a/app/src/main/java/com/memekeyboard/MemeManager.java
+++ b/app/src/main/java/com/memekeyboard/MemeManager.java
@@ -32,8 +32,9 @@ public class MemeManager {
         }
     }
 
-    public String addMeme(Uri memeUri, Set<String> keywords) throws IOException {
-        String fileName = UUID.randomUUID().toString();
+    public String addMeme(Uri memeUri, Set<String> keywords, boolean asSticker) throws IOException {
+        String prefix = asSticker ? "sticker_" : "image_";
+        String fileName = prefix + UUID.randomUUID().toString();
         File newMemeFile = new File(memeFolder, fileName);
 
         try (InputStream inputStream = context.getContentResolver().openInputStream(memeUri);

--- a/app/src/main/res/layout/add_meme_layout.xml
+++ b/app/src/main/res/layout/add_meme_layout.xml
@@ -27,6 +27,25 @@
         android:hint="Palavras-chave (separadas por vírgula)"
         android:layout_marginBottom="16dp"/>
 
+    <RadioGroup
+        android:id="@+id/type_radio_group"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginBottom="16dp">
+        <RadioButton
+            android:id="@+id/image_radio"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Imagem"
+            android:checked="true"/>
+        <RadioButton
+            android:id="@+id/sticker_radio"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Sticker"/>
+    </RadioGroup>
+
     <Button
         android:id="@+id/save_meme_button"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/meme_gallery_layout.xml
+++ b/app/src/main/res/layout/meme_gallery_layout.xml
@@ -32,5 +32,7 @@
         android:text="Add New Meme"
         android:layout_margin="8dp"/>
 
+    <include layout="@layout/keyboard_layout"/>
+
 </LinearLayout>
 

--- a/app/src/main/res/xml/qwerty.xml
+++ b/app/src/main/res/xml/qwerty.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    android:keyWidth="10%p"
+    android:keyHeight="48dp"
+    android:horizontalGap="0dp"
+    android:verticalGap="0dp">
+    <Row>
+        <Key android:codes="113" android:keyLabel="q"/>
+        <Key android:codes="119" android:keyLabel="w"/>
+        <Key android:codes="101" android:keyLabel="e"/>
+        <Key android:codes="114" android:keyLabel="r"/>
+        <Key android:codes="116" android:keyLabel="t"/>
+        <Key android:codes="121" android:keyLabel="y"/>
+        <Key android:codes="117" android:keyLabel="u"/>
+        <Key android:codes="105" android:keyLabel="i"/>
+        <Key android:codes="111" android:keyLabel="o"/>
+        <Key android:codes="112" android:keyLabel="p"/>
+    </Row>
+    <Row>
+        <Key android:codes="97" android:keyLabel="a"/>
+        <Key android:codes="115" android:keyLabel="s"/>
+        <Key android:codes="100" android:keyLabel="d"/>
+        <Key android:codes="102" android:keyLabel="f"/>
+        <Key android:codes="103" android:keyLabel="g"/>
+        <Key android:codes="104" android:keyLabel="h"/>
+        <Key android:codes="106" android:keyLabel="j"/>
+        <Key android:codes="107" android:keyLabel="k"/>
+        <Key android:codes="108" android:keyLabel="l"/>
+    </Row>
+    <Row>
+        <Key android:codes="-1" android:keyLabel="ABC" android:keyWidth="15%p"/>
+        <Key android:codes="122" android:keyLabel="z"/>
+        <Key android:codes="120" android:keyLabel="x"/>
+        <Key android:codes="99" android:keyLabel="c"/>
+        <Key android:codes="118" android:keyLabel="v"/>
+        <Key android:codes="98" android:keyLabel="b"/>
+        <Key android:codes="110" android:keyLabel="n"/>
+        <Key android:codes="109" android:keyLabel="m"/>
+        <Key android:codes="-5" android:keyIcon="@android:drawable/ic_input_delete" android:keyWidth="15%p"/>
+    </Row>
+    <Row>
+        <Key android:codes="32" android:keyLabel="space" android:keyWidth="50%p"/>
+        <Key android:codes="10" android:keyLabel="Enter" android:keyWidth="20%p"/>
+    </Row>
+</Keyboard>


### PR DESCRIPTION
## Summary
- add a qwerty key layout and include a keyboard panel in the meme layout
- allow choosing meme type (image or sticker) when adding new memes
- extend `MemeManager` to store type information
- handle key presses in `MemeKeyboardService` so the search box can be used with the custom keyboard

## Testing
- `./gradlew assembleDebug` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6877fe19f108832a8f4bff5afe7032e9