### PR TITLE
Fix deletion crash and provider metadata

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,16 @@
                 android:resource="@xml/method" />
         </service>
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/memekeyboard/MemeKeyboardService.java
+++ b/app/src/main/java/com/memekeyboard/MemeKeyboardService.java
@@ -75,15 +75,10 @@ public class MemeKeyboardService extends InputMethodService implements KeyboardV
             @Override
             public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
                 final String memePath = (String) memeAdapter.getItem(position);
-                new androidx.appcompat.app.AlertDialog.Builder(MemeKeyboardService.this)
-                        .setTitle(R.string.remove_meme_title)
-                        .setMessage(R.string.remove_meme_message)
-                        .setPositiveButton(android.R.string.yes, (dialog, which) -> {
-                            memeManager.deleteMeme(memePath);
-                            refreshMemeList();
-                        })
-                        .setNegativeButton(android.R.string.no, null)
-                        .show();
+                memeManager.deleteMeme(memePath);
+                refreshMemeList();
+                android.widget.Toast.makeText(MemeKeyboardService.this,
+                        R.string.meme_removed_toast, android.widget.Toast.LENGTH_SHORT).show();
                 return true;
             }
         });

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,5 +5,6 @@
     <string name="switch_keyboard">Switch Keyboard</string>
     <string name="remove_meme_title">Remove meme</string>
     <string name="remove_meme_message">Do you want to remove this meme?</string>
+    <string name="meme_removed_toast">Meme removed</string>
 </resources>
 


### PR DESCRIPTION
## Summary
- register FileProvider in module manifest
- remove long-press dialog and show a toast instead

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68780935400c832ab4eb46d7e185f05f