### PR TITLE
Fix content sharing and add delete confirmation

### DIFF
--- a/app/src/main/java/com/memekeyboard/MemeKeyboardService.java
+++ b/app/src/main/java/com/memekeyboard/MemeKeyboardService.java
@@ -19,6 +19,8 @@ import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.GridView;
+import androidx.appcompat.app.AlertDialog;
+import android.content.DialogInterface;
 
 import androidx.core.content.FileProvider;
 import androidx.core.view.inputmethod.InputConnectionCompat;
@@ -75,10 +77,20 @@ public class MemeKeyboardService extends InputMethodService implements KeyboardV
             @Override
             public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
                 final String memePath = (String) memeAdapter.getItem(position);
-                memeManager.deleteMeme(memePath);
-                refreshMemeList();
-                android.widget.Toast.makeText(MemeKeyboardService.this,
-                        R.string.meme_removed_toast, android.widget.Toast.LENGTH_SHORT).show();
+                new AlertDialog.Builder(MemeKeyboardService.this)
+                        .setTitle(R.string.remove_meme_title)
+                        .setMessage(R.string.remove_meme_message)
+                        .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                memeManager.deleteMeme(memePath);
+                                refreshMemeList();
+                                android.widget.Toast.makeText(MemeKeyboardService.this,
+                                        R.string.meme_removed_toast, android.widget.Toast.LENGTH_SHORT).show();
+                            }
+                        })
+                        .setNegativeButton(android.R.string.cancel, null)
+                        .show();
                 return true;
             }
         });

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -4,5 +4,10 @@
         android:label="@string/subtype_generic"
         android:imeSubtypeLocale="en_US"
         android:imeSubtypeMode="keyboard" />
+    <content
+        android:authority="com.memekeyboard.fileprovider"
+        android:mimeType="image/*"
+        android:mimeType="video/*"
+        android:mimeType="audio/*" />
 </input-method>
 


### PR DESCRIPTION
## Summary
- specify keyboard content types so apps receive images/audio/video
- prompt before deleting a meme

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68780b749a48832ab3d71b68d71729f7