### PR TITLE
Fix invalid method.xml

### DIFF
--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -6,8 +6,6 @@
         android:imeSubtypeMode="keyboard" />
     <content
         android:authority="com.memekeyboard.fileprovider"
-        android:mimeType="image/*"
-        android:mimeType="video/*"
-        android:mimeType="audio/*" />
+        android:mimeType="*/*" />
 </input-method>
 


### PR DESCRIPTION
## Summary
- remove duplicate `mimeType` attributes in `method.xml`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68780d348bb4832aa8287fba60f46156