### PR TITLE
Fix resource linking issue in method.xml

### DIFF
--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -4,8 +4,5 @@
         android:label="@string/subtype_generic"
         android:imeSubtypeLocale="en_US"
         android:imeSubtypeMode="keyboard" />
-    <content
-        android:authority="com.memekeyboard.fileprovider"
-        android:mimeType="*/*" />
 </input-method>
 


### PR DESCRIPTION
## Summary
- remove invalid `content` block from `method.xml`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68780fb460a4832a812748be950dc567