### PR TITLE
Remove share sheet fallback for unsupported content

### DIFF
--- a/app/src/main/java/com/memekeyboard/MemeKeyboardService.java
+++ b/app/src/main/java/com/memekeyboard/MemeKeyboardService.java
@@ -227,21 +227,13 @@ public class MemeKeyboardService extends InputMethodService implements KeyboardV
                     return;
                 }
 
-                if (mimeType.startsWith("audio/") || mimeType.startsWith("video/")) {
-                    Intent share = new Intent(Intent.ACTION_SEND);
-                    share.setType(mimeType);
-                    share.putExtra(Intent.EXTRA_STREAM, contentUri);
-                    share.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                    Intent chooser = Intent.createChooser(share, getString(R.string.share_meme));
-                    chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    startActivity(chooser);
-                    return;
-                }
-
                 ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
                 ClipData clip = ClipData.newUri(getContentResolver(), "Meme", contentUri);
                 clipboard.setPrimaryClip(clip);
                 ic.commitText(contentUri.toString(), 1);
+                android.widget.Toast.makeText(this,
+                        R.string.unsupported_direct_share,
+                        android.widget.Toast.LENGTH_SHORT).show();
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,5 +7,6 @@
     <string name="remove_meme_message">Do you want to remove this meme?</string>
     <string name="meme_removed_toast">Meme removed</string>
     <string name="share_meme">Share meme</string>
+    <string name="unsupported_direct_share">Unable to send directly. Link copied to clipboard.</string>
 </resources>
 


### PR DESCRIPTION
## Summary
- drop Android share menu when inserting media fails
- show a toast informing the user that direct share isn't supported

## Testing
- `./gradlew --version`
- `./gradlew assembleDebug` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68781ba18468832a89863809d3469238