### PR TITLE
Enable direct sticker sharing via commitContent

### DIFF
--- a/app/src/main/java/com/memekeyboard/MemeKeyboardService.java
+++ b/app/src/main/java/com/memekeyboard/MemeKeyboardService.java
@@ -221,9 +221,17 @@ public class MemeKeyboardService extends InputMethodService implements KeyboardV
 
                 InputContentInfoCompat info = new InputContentInfoCompat(contentUri,
                         new ClipDescription(memeFile.getName(), new String[]{mimeType}), null);
+
+                try {
+                    info.requestPermission();
+                } catch (Exception e) {
+                    // Ignore; requesting permission may fail on older APIs
+                }
+
                 EditorInfo editorInfo = getCurrentInputEditorInfo();
                 if (InputConnectionCompat.commitContent(ic, editorInfo, info,
                         InputConnectionCompat.INPUT_CONTENT_GRANT_READ_URI_PERMISSION, opts)) {
+                    info.releasePermission();
                     return;
                 }
 


### PR DESCRIPTION
## Summary
- handle permission request on `InputContentInfoCompat` before sending
- release permission on success

This allows messaging apps such as WhatsApp to receive stickers directly instead of falling back to plain text.

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878237aaf2c832aaa97e1284a3a6fc5