### PR TITLE
Fix sticker share via commit content

### DIFF
--- a/app/src/main/java/com/memekeyboard/MemeKeyboardService.java
+++ b/app/src/main/java/com/memekeyboard/MemeKeyboardService.java
@@ -26,6 +26,7 @@ import android.content.DialogInterface;
 import androidx.core.content.FileProvider;
 import androidx.core.view.inputmethod.InputConnectionCompat;
 import androidx.core.view.inputmethod.InputContentInfoCompat;
+import androidx.core.view.inputmethod.EditorInfoCompat;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -46,6 +47,13 @@ public class MemeKeyboardService extends InputMethodService implements KeyboardV
     public void onCreate() {
         super.onCreate();
         memeManager = new MemeManager(this);
+    }
+
+    @Override
+    public void onStartInput(EditorInfo attribute, boolean restarting) {
+        super.onStartInput(attribute, restarting);
+        String[] mimeTypes = new String[] {"image/png", "image/gif", "image/jpeg", "image/webp"};
+        EditorInfoCompat.setContentMimeTypes(attribute, mimeTypes);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- allow the keyboard to declare supported MIME types
- register image & webp types so commitContent can send stickers

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_687906828184832a9e9522ff1d765e87