### PR TITLE
Fix sticker fallback

### DIFF
--- a/app/src/main/java/com/memekeyboard/MemeKeyboardService.java
+++ b/app/src/main/java/com/memekeyboard/MemeKeyboardService.java
@@ -227,8 +227,12 @@ public class MemeKeyboardService extends InputMethodService implements KeyboardV
                 Bundle opts = new Bundle();
                 opts.putBoolean("IS_STICKER", isSticker);
 
+                String[] descMimeTypes = mimeType.startsWith("image/")
+                        ? new String[]{mimeType, "image/*"}
+                        : new String[]{mimeType};
+
                 InputContentInfoCompat info = new InputContentInfoCompat(contentUri,
-                        new ClipDescription(memeFile.getName(), new String[]{mimeType}), null);
+                        new ClipDescription(memeFile.getName(), descMimeTypes), null);
 
                 try {
                     info.requestPermission();


### PR DESCRIPTION
## Summary
- fallback to share intent only for audio/video, not images
- include generic `image/*` MIME hint when committing image content

## Testing
- `./gradlew test --console plain --no-daemon` *(fails: unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68790bac42ac832abd9782c3bc7bbf9f